### PR TITLE
[Refactor] Set TopAppBar background color

### DIFF
--- a/checkout-android/src/main/java/com/khalti/checkout/payment/KhaltiPaymentPage.kt
+++ b/checkout-android/src/main/java/com/khalti/checkout/payment/KhaltiPaymentPage.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -95,6 +96,9 @@ private fun PaymentAppBar(
                     )
                 }
             },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = Color(0xFFE8F0F7)
+            )
         )
     }
 }


### PR DESCRIPTION
The background color of the TopAppBar in KhaltiPaymentPage has been set to `#E8F0F7`.